### PR TITLE
chore(*) Update travis node version required to 8 minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - '7'
+  - 8

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "winston": "^2.3.1"
   },
   "engines": {
-    "node": "~6.4.0"
+    "node": ">=8.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
## Update travis node version required to 8 minimum

### Description of the Change

Travis build errored because of yarn do not support nodejs v7

Yarn do not support nodejs v7. Should be upgraded on travis build to 8.0.0 at minimum

### Benefits

Travis build works